### PR TITLE
Fix finding the maps.jar archive

### DIFF
--- a/GoogleMaps/bindings/Makefile
+++ b/GoogleMaps/bindings/Makefile
@@ -43,7 +43,7 @@ define get-descriptions.in-to-merge
 endef
 
 define get-maps.jar-path
-$(strip $(shell find $(ANDROID_SDK_PATH)/ -path \*addon-google_apis-google-$(1)/libs/maps.jar | grep '\<$(1)\>'))
+$(strip $(shell find $(ANDROID_SDK_PATH)/ -regex '.\*addon-google_apis-google\(_inc_\)\*-$(1)/libs/maps.jar' | grep '\<$(1)\>'))
 endef
 
 API_DESCRIPTIONS_IN := $(call get-descriptions.in-to-merge,$(lastword $(API_LEVELS)))


### PR DESCRIPTION
The current -path value passed to find will ignore all the APIs older than 16. The addon path
format used before 16 is

  addon-google_apis-google_inc_-X

while with 16 and up it is

  addon-google_apis-google-X

The patch uses -regex instead of -path to cope with the above.
